### PR TITLE
Revert "Revert "Revert "Add PRODUCT_BOOTANIMATION"""

### DIFF
--- a/core/product.mk
+++ b/core/product.mk
@@ -73,7 +73,6 @@ endef
 #
 
 _product_var_list := \
-    PRODUCT_BOOTANIMATION \
     PRODUCT_BUILD_PROP_OVERRIDES \
     PRODUCT_NAME \
     PRODUCT_MODEL \

--- a/core/product_config.mk
+++ b/core/product_config.mk
@@ -356,12 +356,6 @@ endif
 # The optional :<owner> is used to indicate the owner of a vendor file.
 PRODUCT_COPY_FILES := \
     $(strip $(PRODUCTS.$(INTERNAL_PRODUCT).PRODUCT_COPY_FILES))
-_boot_animation := $(strip $(lastword $(PRODUCTS.$(INTERNAL_PRODUCT).PRODUCT_BOOTANIMATION)))
-ifneq ($(_boot_animation),)
-PRODUCT_COPY_FILES += \
-    $(_boot_animation):system/media/bootanimation.zip
-endif
-_boot_animation :=
 
 # We might want to skip items listed in PRODUCT_COPY_FILES for
 # various reasons. This is useful for replacing a binary module with one


### PR DESCRIPTION
New build server(s) will be able to support the new
boot animation generation process, so we no longer need this.

This reverts commit 34e1e204e5eaeb2b6563547c57f4febd24bd797d.

Change-Id: Ib08227cecbb1e3926d09c9125f3714a4dc380876