### PR TITLE
Add dumpvar for WITH_SU

### DIFF
--- a/core/dumpvar.mk
+++ b/core/dumpvar.mk
@@ -25,12 +25,13 @@ print_build_config_vars := \
   BUILD_ID \
   OUT_DIR
 
-ifneq (,$(filter true, $(CYNGN_TARGET) $(EXTERNAL_CLEAN_TARGET)))
-ifeq ($(CYNGN_TARGET),true)
+ifeq ($(WITH_SU),true)
 print_build_config_vars += \
-  CYNGN_TARGET \
-  CYNGN_FEATURES
+  WITH_SU
 endif
+ifeq ($(WITH_GMS),true)
+print_build_config_vars += \
+  WITH_GMS
 endif
 
 ifeq ($(TARGET_BUILD_PDK),true)


### PR DESCRIPTION
 -Allow folks to see easily if the term session they are in has
   WITH_SU set to true
 -Also add a dumpvar rule for WITH_GMS for those that have it
 -Remove unused CYNGN dumpvar rules

Change-Id: I9b3f7f729e31dee90caa366fe4798bbcea9e566f