### PR TITLE
Add dumpvar for WITH_GMS

### DIFF
--- a/core/dumpvar.mk
+++ b/core/dumpvar.mk
@@ -33,6 +33,10 @@ ifeq ($(WITH_SU),true)
 print_build_config_vars += \
   WITH_SU
 endif
+ifeq ($(WITH_GMS),true)
+print_build_config_vars += \
+  WITH_GMS
+endif
 
 ifeq ($(TARGET_BUILD_PDK),true)
 print_build_config_vars += \


### PR DESCRIPTION
This got dropped after caf-rebase and was missed in
  010ce6f3a21c73d1eb86c4558974d83e5edf5d5a

Change-Id: I1a0d18e3c3c7b27a3e0d2590caec498e77bfeca6