### PR TITLE
Avoid adding an extra slash if OUT_DIR_COMMON_BASE ends in a slash

### DIFF
--- a/core/envsetup.mk
+++ b/core/envsetup.mk
@@ -217,7 +217,7 @@ else
 OUT_DIR := $(CURDIR)/out
 endif
 else
-OUT_DIR := $(OUT_DIR_COMMON_BASE)/$(notdir $(PWD))
+OUT_DIR := $(OUT_DIR_COMMON_BASE:/=)/$(notdir $(PWD))
 endif
 endif
 


### PR DESCRIPTION
The extra slash can create all kinds of problems throughout the
makefiles.  In particular, it caused a device to become unbootable
because the ramdisk was incomplete due to mismatched filenames
(some containing / and some containing //).

Change-Id: I9dbb425aaf51e7ed2697dba0034f2ee92ab3c82b