### PR TITLE
Fix warning with AAPT2 and LOCAL_STATIC_ANDROID_LIBRARIES

### DIFF
--- a/core/definitions.mk
+++ b/core/definitions.mk
@@ -426,7 +426,7 @@ endef
 define find-subdir-assets
 $(sort $(if $(1),$(patsubst ./%,%, \
 	$(shell if [ -d $(1) ] ; then cd $(1) ; find -L ./ -not -name '.*' -and -type f -and -not -type l ; fi)), \
-	$(warning Empty argument supplied to find-subdir-assets) \
+	$(warning Empty argument supplied to find-subdir-assets in $(LOCAL_PATH)) \
 ))
 endef
 

--- a/core/package_internal.mk
+++ b/core/package_internal.mk
@@ -140,9 +140,9 @@ my_overlay_resources := $(strip \
     $(addprefix $(d)/, \
         $(call find-subdir-assets,$(d)))))
 
-my_res_resources := $(strip \
+my_res_resources := $(if $(my_res_dir),$(strip \
     $(addprefix $(my_res_dir)/, \
-        $(call find-subdir-assets,$(my_res_dir))))
+        $(call find-subdir-assets,$(my_res_dir)))))
 
 all_resources := $(strip $(my_res_resources) $(my_overlay_resources))
 


### PR DESCRIPTION
Building with LOCAL_STATIC_ANDROID_LIBARIES and LOCAL_USE_APPT2
causes a warning:
build/core/package_internal.mk:143: Empty argument supplied to find-subdir-assets

Only call find-subdir-assets if my_res_dir is not empty.

Also improve the warning message to make it easier to find the module
that caused it.

Test: m -j
Change-Id: I9a71162c7e2ed82f64d6844baca256968ac77317