### PR TITLE
core: Prefix and build bison host executable if needed

### DIFF
--- a/core/binary.mk
+++ b/core/binary.mk
@@ -891,7 +891,7 @@ y_yacc_cs := $(addprefix \
 ifneq ($(y_yacc_cs),)
 $(y_yacc_cs): $(intermediates)/%.c: \
     $(TOPDIR)$(LOCAL_PATH)/%.y \
-    $(my_additional_dependencies)
+    $(my_additional_dependencies) | $(BISON)
 	$(call transform-y-to-c-or-cpp)
 $(call track-src-file-gen,$(y_yacc_sources),$(y_yacc_cs))
 
@@ -904,7 +904,7 @@ yy_yacc_cpps := $(addprefix \
 ifneq ($(yy_yacc_cpps),)
 $(yy_yacc_cpps): $(intermediates)/%$(LOCAL_CPP_EXTENSION): \
     $(TOPDIR)$(LOCAL_PATH)/%.yy \
-    $(my_additional_dependencies)
+    $(my_additional_dependencies) | $(BISON)
 	$(call transform-y-to-c-or-cpp)
 $(call track-src-file-gen,$(yy_yacc_sources),$(yy_yacc_cpps))
 

--- a/core/config.mk
+++ b/core/config.mk
@@ -535,7 +535,7 @@ endif
 # BISON_PKGDATADIR.
 BISON_PKGDATADIR := $(PWD)/external/bison/data
 ifeq ($(USE_HOST_BISON),yes)
-BISON := bison
+BISON := $(HOST_OUT_EXECUTABLES)/bison
 else
 BISON := prebuilts/misc/$(BUILD_OS)-$(HOST_PREBUILT_ARCH)/bison/bison
 endif


### PR DESCRIPTION
This patch prefixed bison with HOST_OUT_EXECUTABLES to ensure using our
`bison` built from source. It also added bison to be a depencency of %.y
and %.yy tasks so that it will be built if needed without any manual
`mka bison`.

Change-Id: Ic207124965c704b3f350e96b58d8e1f2683c2601